### PR TITLE
Fix missing import in desktop.

### DIFF
--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use debug_print::debug_println;
 use lazy_static::lazy_static;
-use tauri::{Manager, Runtime};
+use tauri::{Manager, Runtime, Emitter};
 use tokio::{
     io,
     net::UdpSocket,


### PR DESCRIPTION
When attempting to use the tauri-plugin-udp with tauri v2.0.0-beta.24, I encountered a compile-time error:

```
error[E0599]: no method named `emit_to` found for reference `&AppHandle<R>` in the current scope
   --> ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tauri-plugin-udp-0.1.0/src/desktop.rs:47:45
    |
47  |                 let _ = window.app_handle().emit_to(

```

Adding an import for tauri::Emitter resolves the error.