### PR TITLE
Fix compilation issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ tauri-plugin = { version = "2.0.1", features = ["build"] }
 tauri = { version = "2.0.4" }
 serde = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.37.0", features = [] }
+tokio = { version = "1.37.0", features = ["net", "time"] }
 lazy_static = "1.4.0"
 debug_print = "1.0.0"


### PR DESCRIPTION
The plugin cannot be compiled and throws an error because of missing `tokio` features:
```
error[E0432]: unresolved import `tokio::net::UdpSocket`
 --> src/models.rs:3:5
  |
3 | use tokio::net::UdpSocket;
  |     ^^^^^^^^^^^^^^^^^^^^^ no `UdpSocket` in `net`
  |
help: consider importing this struct instead
  |
3 | use std::net::UdpSocket;
  |     ~~~~~~~~~~~~~~~~~~~

error[E0432]: unresolved imports `tokio::net::UdpSocket`, `tokio::time`, `tokio::time`
   --> src/platform.rs:8:5
    |
8   |     net::UdpSocket,
    |     ^^^^^^^^^^^^^^ no `UdpSocket` in `net`
9   |     sync::RwLock,
10  |     time::{self, sleep},
    |     ^^^^   ^^^^ no `time` in the root
    |     |
    |     could not find `time` in `tokio`
    |
```
The error occurs also in example projects.
Proposed fix adds missing features of `tokio` package.
The issue is resolved with this fix.
Default features for `tokio` is none - https://github.com/tokio-rs/tokio/blob/master/tokio/Cargo.toml 

_The issue was encountered and fixed on arm64, macOS Sonoma 14.7.2, with rustc v1.82.0, Node.js v20.15.0, npm v10.7.0. Tested both with `tokio` v1.37.0 and `tokio` v1.43.0 (latest)_ 
